### PR TITLE
Update NixOS Wiki link

### DIFF
--- a/docs/awesome/awesome-nix.md
+++ b/docs/awesome/awesome-nix.md
@@ -261,4 +261,3 @@
 * [Discourse](https://discourse.nixos.org/) - The best place to get help and discuss Nix-related topics.
 * [NixCon](https://nixcon.org/) - The annual community conference for contributors and users of Nix and NixOS.
 * [Wiki (Official)](https://wiki.nixos.org)
-* [Wiki (Unofficial)](https://nixos.wiki)


### PR DESCRIPTION
Hello there 👋!

The NixOS wiki is in the process of migrating from https://nixos.wiki to https://wiki.nixos.org.
You can find more information about it [here](https://github.com/NixOS/foundation/issues/113).

You seem to be using the old link in your repository, which is why we send you this PR.
If you feel like this is not correct or have any questions, feel free to [get in touch with us](https://github.com/NixOS/nixos-wiki-infra/issues/105).


Have a great day,

-- The NixOS Wiki-Team ❄️